### PR TITLE
HHH-8091 Hibernate produces SQL - "in ()" - which is invalid in at least Oracle, MySQL and Postgres

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
+++ b/hibernate-core/src/main/java/org/hibernate/event/internal/DefaultSaveOrUpdateEventListener.java
@@ -124,7 +124,7 @@ public class DefaultSaveOrUpdateEventListener extends AbstractSaveEventListener 
 			}
 			else {
 
-				final boolean isEqual = entityEntry.getPersister().getIdentifierType()
+				final boolean isEqual = !entityEntry.getPersister().getIdentifierType()
 						.isEqual( requestedId, entityEntry.getId(), factory );
 
 				if ( isEqual ) {

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -641,7 +641,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 					beforePlaceholder,
 					afterPlaceholder,
 					sourceToken,
-					expansionList.toString(),
+					expansionList.isEmpty() ? "null" : expansionList.toString(),
 					true,
 					true
 			);

--- a/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/query/internal/QueryParameterBindingsImpl.java
@@ -641,7 +641,7 @@ public class QueryParameterBindingsImpl implements QueryParameterBindings {
 					beforePlaceholder,
 					afterPlaceholder,
 					sourceToken,
-					expansionList.isEmpty() ? "null" : expansionList.toString(),
+					expansionList.length() == 0 ? "null" : expansionList.toString(),
 					true,
 					true
 			);


### PR DESCRIPTION
replace "in ()" with "in (null)" if parameters list is empty